### PR TITLE
Authentication support for GitHub Apps

### DIFF
--- a/github-previews.cabal
+++ b/github-previews.cabal
@@ -26,8 +26,14 @@ library
   hs-source-dirs:      src
 
   build-depends:
-      base   >= 4.7  && < 5
-    , github >= 0.20 && < 0.21
+      base        >= 4.7      && < 5
+    , aeson       >= 1.4.0.0  && < 1.5
+    , bytestring  >= 0.10.4.0 && < 0.11
+    , github      >= 0.21     && < 0.22
+    , http-client >= 0.5.12   && < 0.7
+    , mtl         >= 2.1.3.1  && < 2.2  || >= 2.2.1 && < 2.3
+    , tagged
+    , text        >= 1.2.0.6  && < 1.3
 
   default-extensions:
     DataKinds
@@ -38,6 +44,11 @@ library
 
   exposed-modules:
     GitHub.Previews
+    GitHub.Previews.Auth
+    GitHub.Previews.Data
+    GitHub.Previews.Data.Apps
+    GitHub.Previews.Data.Webhooks
+    GitHub.Previews.Endpoints.Apps
 
 source-repository head
   type:     git

--- a/src/GitHub/Previews/Auth.hs
+++ b/src/GitHub/Previews/Auth.hs
@@ -1,0 +1,37 @@
+module GitHub.Previews.Auth (
+    AppAuth (..),
+    ) where
+
+import GitHub.Internal.Prelude
+import Prelude ()
+
+import GitHub.Auth (AuthMethod (..))
+
+import qualified Data.ByteString     as BS
+import qualified Network.HTTP.Client as HTTP
+
+-- | Custom API endpoint without trailing slash
+type Endpoint = Text
+
+type Token = BS.ByteString
+
+-- | The Github App auth data type
+data AppAuth
+    = JWT Token                -- ^ JWT
+    | EnterpriseJWT Text Token -- ^ Custom endpoint and JWT
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData AppAuth where rnf = genericRnf
+instance Binary AppAuth
+instance Hashable AppAuth
+
+instance AuthMethod AppAuth where
+    endpoint (JWT _)             = Nothing
+    endpoint (EnterpriseJWT e _) = Just e
+
+    setAuthRequest (JWT t)             = setAuthHeader $ "Bearer " <> t
+    setAuthRequest (EnterpriseJWT _ t) = setAuthHeader $ "Bearer " <> t
+
+setAuthHeader :: BS.ByteString -> HTTP.Request -> HTTP.Request
+setAuthHeader auth req =
+    req { HTTP.requestHeaders = ("Authorization", auth) : HTTP.requestHeaders req }

--- a/src/GitHub/Previews/Data.hs
+++ b/src/GitHub/Previews/Data.hs
@@ -1,0 +1,19 @@
+module GitHub.Previews.Data (
+    -- * Tagged types
+    -- ** Id
+    mkInstallationId,
+    -- * Module re-exports
+    module GitHub.Previews.Auth,
+    module GitHub.Previews.Data.Apps,
+    ) where
+
+import GitHub.Internal.Prelude
+import Prelude ()
+
+import GitHub.Data.Id (Id (..))
+
+import GitHub.Previews.Auth
+import GitHub.Previews.Data.Apps
+
+mkInstallationId :: Int -> Id Installation
+mkInstallationId = Id

--- a/src/GitHub/Previews/Data/Apps.hs
+++ b/src/GitHub/Previews/Data/Apps.hs
@@ -1,0 +1,27 @@
+module GitHub.Previews.Data.Apps where
+
+import GitHub.Internal.Prelude
+import Prelude ()
+
+-- | Currently only used for Id Installation
+data Installation = Installation
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+-- | Response type for a new access token
+data AccessToken = AccessToken
+    { accessTokenToken      :: !Text
+    , accessTokenExpiration :: !UTCTime
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData AccessToken where rnf = genericRnf
+instance Binary AccessToken
+
+-------------------------------------------------------------------------------
+-- JSON instances
+-------------------------------------------------------------------------------
+
+instance FromJSON AccessToken where
+  parseJSON = withObject "AccessToken" $ \o -> AccessToken
+      <$> o .: "token"
+      <*> o .: "expires_at"

--- a/src/GitHub/Previews/Data/Webhooks.hs
+++ b/src/GitHub/Previews/Data/Webhooks.hs
@@ -1,0 +1,20 @@
+module GitHub.Previews.Data.Webhooks where
+
+import GitHub.Internal.Prelude
+import Prelude ()
+
+import GitHub.Data.Id (Id)
+
+import GitHub.Previews.Data.Apps (Installation)
+
+data AppInstallation = AppInstallation
+    { appInstallationId :: !(Id Installation)
+    }
+  deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData AppInstallation where rnf = genericRnf
+instance Binary AppInstallation
+
+instance FromJSON AppInstallation where
+    parseJSON = withObject "AppInstallation" $ \o -> AppInstallation
+        <$> o .: "id"

--- a/src/GitHub/Previews/Endpoints/Apps.hs
+++ b/src/GitHub/Previews/Endpoints/Apps.hs
@@ -1,0 +1,23 @@
+module GitHub.Previews.Endpoints.Apps
+    ( createAccessToken
+    , createAccessTokenR
+    ) where
+
+import GitHub.Internal.Prelude
+import Prelude ()
+
+import GitHub.Data
+import GitHub.Request
+
+import GitHub.Previews.Data
+
+-- | Create an access token for a given installation.
+createAccessToken :: AppAuth -> Id Installation -> IO (Either Error AccessToken)
+createAccessToken auth installation =
+    executeRequest auth $ createAccessTokenR installation
+
+-- | Create an access token for a given installation.
+-- See <https://developer.github.com/v3/apps/#create-a-new-installation-token>
+createAccessTokenR :: Id Installation -> GenRequest 'MtMachineManPreview 'RW AccessToken
+createAccessTokenR installation =
+    Command Post ["app", "installations", toPathPart installation, "access_tokens"] mempty

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,6 @@
-resolver: nightly-2019-02-14
+resolver: lts-13.18
 packages:
 - .
+extra-deps:
+- git: https://github.com/robbiemcmichael/github
+  commit: 6f029720d5f98bd0206ab2101ba6a62d807e97b7


### PR DESCRIPTION
Adds the ability to authenticate as a [GitHub App](https://developer.github.com/apps/) and create an access token for an installation of the app. Authenticating as a GitHub App [uses a JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/) instead of the usual OAuth tokens.