### PR TITLE
Add support for check runs

### DIFF
--- a/github-previews.cabal
+++ b/github-previews.cabal
@@ -47,8 +47,11 @@ library
     GitHub.Previews.Auth
     GitHub.Previews.Data
     GitHub.Previews.Data.Apps
+    GitHub.Previews.Data.CheckRuns
+    GitHub.Previews.Data.CheckSuites
     GitHub.Previews.Data.Webhooks
     GitHub.Previews.Endpoints.Apps
+    GitHub.Previews.Endpoints.Checks.CheckRuns
 
 source-repository head
   type:     git

--- a/src/GitHub/Previews/Data.hs
+++ b/src/GitHub/Previews/Data.hs
@@ -5,6 +5,7 @@ module GitHub.Previews.Data (
     -- * Module re-exports
     module GitHub.Previews.Auth,
     module GitHub.Previews.Data.Apps,
+    module GitHub.Previews.Data.CheckRuns,
     ) where
 
 import GitHub.Internal.Prelude
@@ -14,6 +15,7 @@ import GitHub.Data.Id (Id (..))
 
 import GitHub.Previews.Auth
 import GitHub.Previews.Data.Apps
+import GitHub.Previews.Data.CheckRuns
 
 mkInstallationId :: Int -> Id Installation
 mkInstallationId = Id

--- a/src/GitHub/Previews/Data/Apps.hs
+++ b/src/GitHub/Previews/Data/Apps.hs
@@ -3,9 +3,30 @@ module GitHub.Previews.Data.Apps where
 import GitHub.Internal.Prelude
 import Prelude ()
 
--- | Currently only used for Id Installation
+import GitHub.Data
+
+-- | Type for a GitHub App
+data App = App
+    { appId          :: !(Id App)
+    , appOwner       :: !SimpleOwner
+    , appName        :: !(Name App)
+    , appDescription :: !(Maybe Text)
+    , appExternalUrl :: !URL
+    , appHtmlUrl     :: !URL
+    , appCreatedAt   :: !UTCTime
+    , appUpdatedAt   :: !UTCTime
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData App where rnf = genericRnf
+instance Binary App
+
+-- | Currently only used for @Id Installation@
 data Installation = Installation
     deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData Installation where rnf = genericRnf
+instance Binary Installation
 
 -- | Response type for a new access token
 data AccessToken = AccessToken
@@ -20,6 +41,17 @@ instance Binary AccessToken
 -------------------------------------------------------------------------------
 -- JSON instances
 -------------------------------------------------------------------------------
+
+instance FromJSON App where
+  parseJSON = withObject "App" $ \o -> App
+      <$> o .:  "id"
+      <*> o .:  "owner"
+      <*> o .:  "name"
+      <*> o .:? "description"
+      <*> o .:  "external_url"
+      <*> o .:  "html_url"
+      <*> o .:  "created_at"
+      <*> o .:  "updated_at"
 
 instance FromJSON AccessToken where
   parseJSON = withObject "AccessToken" $ \o -> AccessToken

--- a/src/GitHub/Previews/Data/CheckRuns.hs
+++ b/src/GitHub/Previews/Data/CheckRuns.hs
@@ -1,0 +1,318 @@
+{-# LANGUAGE RecordWildCards #-}
+module GitHub.Previews.Data.CheckRuns where
+
+import GitHub.Internal.Prelude
+import Prelude ()
+
+import qualified Data.Text as T
+
+import GitHub.Data
+
+import GitHub.Previews.Data.Apps
+import GitHub.Previews.Data.CheckSuites
+
+data CheckRun = CheckRun
+    { checkRunId           :: !(Id CheckRun)
+    , checkRunName         :: !Text
+    , checkRunHeadSha      :: !(Name Commit)
+    , checkRunDetailsUrl   :: !(Maybe URL)
+    , checkRunExternalId   :: !(Maybe Text)
+    , checkRunStatus       :: !CheckRunStatus
+    , checkRunStartedAt    :: !UTCTime
+    , checkRunConclusion   :: !(Maybe CheckRunConclusion)
+    , checkRunCompletedAt  :: !(Maybe UTCTime)
+    , checkRunOutput       :: !(Maybe CheckRunOutput)
+    , checkRunActions      :: !(Vector CheckRunAction)
+    , checkRunCheckSuite   :: !CheckSuiteRef
+    , checkRunApp          :: !App
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData CheckRun where rnf = genericRnf
+instance Binary CheckRun
+
+data NewCheckRun = NewCheckRun
+    { newCheckRunName        :: !Text
+    , newCheckRunHeadSha     :: !(Name Commit)
+    , newCheckRunDetailsUrl  :: !(Maybe URL)
+    , newCheckRunExternalId  :: !(Maybe Text)
+    , newCheckRunStatus      :: !(Maybe CheckRunStatus)
+    , newCheckRunStartedAt   :: !(Maybe UTCTime)
+    , newCheckRunConclusion  :: !(Maybe CheckRunConclusion)
+    , newCheckRunCompletedAt :: !(Maybe UTCTime)
+    , newCheckRunOutput      :: !(Maybe CheckRunOutput)
+    , newCheckRunActions     :: !(Vector CheckRunAction)
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData NewCheckRun where rnf = genericRnf
+instance Binary NewCheckRun
+
+data EditCheckRun = EditCheckRun
+    { editCheckRunName        :: !(Maybe Text)
+    , editCheckRunDetailsUrl  :: !(Maybe URL)
+    , editCheckRunExternalId  :: !(Maybe Text)
+    , editCheckRunStatus      :: !(Maybe CheckRunStatus)
+    , editCheckRunStartedAt   :: !(Maybe UTCTime)
+    , editCheckRunConclusion  :: !(Maybe CheckRunConclusion)
+    , editCheckRunCompletedAt :: !(Maybe UTCTime)
+    , editCheckRunOutput      :: !(Maybe CheckRunOutput)
+    , editCheckRunActions     :: !(Maybe (Vector CheckRunAction))
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData EditCheckRun where rnf = genericRnf
+instance Binary EditCheckRun
+
+data CheckRunStatus
+    = CheckRunQueued
+    | CheckRunInProgress
+    | CheckRunCompleted
+    deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
+
+instance NFData CheckRunStatus where rnf = genericRnf
+instance Binary CheckRunStatus
+
+data CheckRunConclusion
+    = CheckRunSuccess
+    | CheckRunFailure
+    | CheckRunNeutral
+    | CheckRunCancelled
+    | CheckRunTimedOut
+    | CheckRunActionRequired
+    deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
+
+instance NFData CheckRunConclusion where rnf = genericRnf
+instance Binary CheckRunConclusion
+
+data CheckRunOutput = CheckRunOutput
+    { checkRunOutputTitle       :: !(Maybe Text)
+    , checkRunOutputSummary     :: !(Maybe Text)
+    , checkRunOutputText        :: !(Maybe Text)
+    , checkRunOutputAnnotations :: !(Vector CheckRunAnnotation)
+    , checkRunOutputImages      :: !(Vector CheckRunImage)
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData CheckRunOutput where rnf = genericRnf
+instance Binary CheckRunOutput
+
+data CheckRunAnnotation = CheckRunAnnotation
+    { checkRunAnnotationPath            :: !Text
+    , checkRunAnnotationStartLine       :: !Int
+    , checkRunAnnotationEndLine         :: !Int
+    , checkRunAnnotationStartColumn     :: !(Maybe Int)
+    , checkRunAnnotationEndColumn       :: !(Maybe Int)
+    , checkRunAnnotationLevel           :: !CheckRunAnnotationLevel
+    , checkRunAnnotationMessage         :: !Text
+    , checkRunAnnotationTitle           :: !(Maybe Text)
+    , checkRunAnnotationRawDetails      :: !(Maybe Text)
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData CheckRunAnnotation where rnf = genericRnf
+instance Binary CheckRunAnnotation
+
+data CheckRunAnnotationLevel
+    = CheckRunAnnotationNotice
+    | CheckRunAnnotationWarning
+    | CheckRunAnnotationFailure
+    deriving (Show, Data, Enum, Bounded, Typeable, Eq, Ord, Generic)
+
+instance NFData CheckRunAnnotationLevel where rnf = genericRnf
+instance Binary CheckRunAnnotationLevel
+
+data CheckRunImage = CheckRunImage
+    { checkRunImageAlt      :: !Text
+    , checkRunImageImageUrl :: !URL
+    , checkRunImageCaption  :: !(Maybe Text)
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData CheckRunImage where rnf = genericRnf
+instance Binary CheckRunImage
+
+data CheckRunAction = CheckRunAction
+    { checkRunActionLabel       :: !Text
+    , checkRunActionDescription :: !Text
+    , checkRunActionIdentifier  :: !Text
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData CheckRunAction where rnf = genericRnf
+instance Binary CheckRunAction
+
+-------------------------------------------------------------------------------
+-- JSON instances
+-------------------------------------------------------------------------------
+
+instance FromJSON CheckRun where
+  parseJSON = withObject "CheckRun" $ \o -> CheckRun
+      <$> o .:  "id"
+      <*> o .:  "name"
+      <*> o .:  "head_sha"
+      <*> o .:? "details_url"
+      <*> o .:? "external_id"
+      <*> o .:  "status"
+      <*> o .:  "started_at"
+      <*> o .:? "conclusion"
+      <*> o .:? "completed_at"
+      <*> o .:? "output"
+      <*> o .:  "actions"
+      <*> o .:  "check_suite"
+      <*> o .:  "app"
+
+instance ToJSON NewCheckRun where
+    toJSON NewCheckRun{..} = object $ filter notNull $
+        [ "name"         .= newCheckRunName
+        , "head_sha"     .= newCheckRunHeadSha
+        , "details_url"  .= newCheckRunDetailsUrl
+        , "external_id"  .= newCheckRunExternalId
+        , "status"       .= newCheckRunStatus
+        , "started_at"   .= newCheckRunStartedAt
+        , "conclusion"   .= newCheckRunConclusion
+        , "completed_at" .= newCheckRunCompletedAt
+        , "output"       .= newCheckRunOutput
+        , "actions"      .= newCheckRunActions
+        ]
+      where
+        notNull (_, Null) = False
+        notNull (_, _) = True
+
+instance ToJSON EditCheckRun where
+    toJSON EditCheckRun{..} = object $ filter notNull $
+        [ "name"         .= editCheckRunName
+        , "details_url"  .= editCheckRunDetailsUrl
+        , "external_id"  .= editCheckRunExternalId
+        , "status"       .= editCheckRunStatus
+        , "started_at"   .= editCheckRunStartedAt
+        , "conclusion"   .= editCheckRunConclusion
+        , "completed_at" .= editCheckRunCompletedAt
+        , "output"       .= editCheckRunOutput
+        , "actions"      .= editCheckRunActions
+        ]
+      where
+        notNull (_, Null) = False
+        notNull (_, _) = True
+
+instance FromJSON CheckRunStatus where
+    parseJSON = withText "CheckRunStatus" $ \s -> case T.toCaseFold s of
+        "queued"      -> pure CheckRunQueued
+        "in_progress" -> pure CheckRunInProgress
+        "completed"   -> pure CheckRunCompleted
+        _             -> fail $ "Unknown CheckRunStatus " <> T.unpack s
+
+instance ToJSON CheckRunStatus where
+    toJSON CheckRunQueued     = String "queued"
+    toJSON CheckRunInProgress = String "in_progress"
+    toJSON CheckRunCompleted  = String "completed"
+
+instance FromJSON CheckRunConclusion where
+    parseJSON = withText "CheckRunConclusion" $ \s -> case T.toCaseFold s of
+        "success"         -> pure CheckRunSuccess
+        "failure"         -> pure CheckRunFailure
+        "neutral"         -> pure CheckRunNeutral
+        "cancelled"       -> pure CheckRunCancelled
+        "timed_out"       -> pure CheckRunTimedOut
+        "action_required" -> pure CheckRunActionRequired
+        _                 -> fail $ "Unknown CheckRunConclusion " <> T.unpack s
+
+instance ToJSON CheckRunConclusion where
+    toJSON CheckRunSuccess        = String "success"
+    toJSON CheckRunFailure        = String "failure"
+    toJSON CheckRunNeutral        = String "neutral"
+    toJSON CheckRunCancelled      = String "cancelled"
+    toJSON CheckRunTimedOut       = String "timed_out"
+    toJSON CheckRunActionRequired = String "action_required"
+
+instance ToJSON CheckRunOutput where
+    toJSON CheckRunOutput{..} = object $ filter notNull $
+        [ "title"       .= checkRunOutputTitle
+        , "summary"     .= checkRunOutputSummary
+        , "text"        .= checkRunOutputText
+        , "annotations" .= checkRunOutputAnnotations
+        , "images"      .= checkRunOutputImages
+        ]
+      where
+        notNull (_, Null) = False
+        notNull (_, _) = True
+
+instance FromJSON CheckRunOutput where
+    parseJSON = withObject "CheckRunOutput" $ \o -> CheckRunOutput
+        <$> o .:  "title"
+        <*> o .:  "summary"
+        <*> o .:? "text"
+        <*> o .:  "annotations"
+        <*> o .:  "images"
+
+instance ToJSON CheckRunAnnotation where
+    toJSON CheckRunAnnotation{..} = object $ filter notNull $
+        [ "path"             .= checkRunAnnotationPath
+        , "start_line"       .= checkRunAnnotationStartLine
+        , "end_line"         .= checkRunAnnotationEndLine
+        , "start_column"     .= checkRunAnnotationStartColumn
+        , "end_column"       .= checkRunAnnotationEndColumn
+        , "annotation_level" .= checkRunAnnotationLevel
+        , "message"          .= checkRunAnnotationMessage
+        , "title"            .= checkRunAnnotationTitle
+        , "raw_details"      .= checkRunAnnotationRawDetails
+        ]
+      where
+        notNull (_, Null) = False
+        notNull (_, _) = True
+
+instance FromJSON CheckRunAnnotation where
+    parseJSON = withObject "CheckRunAnnotation" $ \o -> CheckRunAnnotation
+        <$> o .:  "path"
+        <*> o .:  "start_line"
+        <*> o .:  "end_line"
+        <*> o .:? "start_column"
+        <*> o .:? "end_column"
+        <*> o .:  "annotation_level"
+        <*> o .:  "message"
+        <*> o .:? "title"
+        <*> o .:? "raw_details"
+
+instance FromJSON CheckRunAnnotationLevel where
+    parseJSON = withText "CheckRunAnnotationLevel" $ \s -> case T.toCaseFold s of
+        "notice"  -> pure CheckRunAnnotationNotice
+        "warning" -> pure CheckRunAnnotationWarning
+        "failure" -> pure CheckRunAnnotationFailure
+        _         -> fail $ "Unknown CheckRunAnnotationLevel " <> T.unpack s
+
+instance ToJSON CheckRunAnnotationLevel where
+    toJSON CheckRunAnnotationNotice  = String "notice"
+    toJSON CheckRunAnnotationWarning = String "warning"
+    toJSON CheckRunAnnotationFailure = String "failure"
+
+instance ToJSON CheckRunImage where
+    toJSON CheckRunImage{..} = object $ filter notNull $
+        [ "alt"       .= checkRunImageAlt
+        , "image_url" .= checkRunImageImageUrl
+        , "caption"   .= checkRunImageCaption
+        ]
+      where
+        notNull (_, Null) = False
+        notNull (_, _) = True
+
+instance FromJSON CheckRunImage where
+    parseJSON = withObject "CheckRunImage" $ \o -> CheckRunImage
+        <$> o .:  "alt"
+        <*> o .:  "image_url"
+        <*> o .:? "caption"
+
+instance ToJSON CheckRunAction where
+    toJSON CheckRunAction{..} = object $ filter notNull $
+        [ "label"       .= checkRunActionLabel
+        , "description" .= checkRunActionDescription
+        , "identifier"  .= checkRunActionIdentifier
+        ]
+      where
+        notNull (_, Null) = False
+        notNull (_, _) = True
+
+instance FromJSON CheckRunAction where
+  parseJSON = withObject "CheckRunAction" $ \o -> CheckRunAction
+      <$> o .: "label"
+      <*> o .: "description"
+      <*> o .: "identifier"

--- a/src/GitHub/Previews/Data/CheckSuites.hs
+++ b/src/GitHub/Previews/Data/CheckSuites.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE RecordWildCards #-}
+module GitHub.Previews.Data.CheckSuites where
+
+import GitHub.Internal.Prelude
+import Prelude ()
+
+import GitHub.Data
+import GitHub.Data.Id
+
+-- | Currently only used for @Id CheckSuite@
+data CheckSuite = CheckSuite
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData CheckSuite where rnf = genericRnf
+instance Binary CheckSuite
+
+-- | Reference to a 'CheckSuite'
+data CheckSuiteRef = CheckSuiteRef
+    { checkSuiteRefId :: !(Id CheckSuite)
+    }
+    deriving (Show, Data, Typeable, Eq, Ord, Generic)
+
+instance NFData CheckSuiteRef where rnf = genericRnf
+instance Binary CheckSuiteRef
+
+-------------------------------------------------------------------------------
+-- JSON instances
+-------------------------------------------------------------------------------
+
+instance ToJSON CheckSuiteRef where
+    toJSON CheckSuiteRef{..} = object $ filter notNull $
+        [ "id" .= checkSuiteRefId
+        ]
+      where
+        notNull (_, Null) = False
+        notNull (_, _) = True
+
+instance FromJSON CheckSuiteRef where
+    parseJSON = withObject "CheckSuiteRef" $ \o -> CheckSuiteRef
+        <$> o .: "id"

--- a/src/GitHub/Previews/Endpoints/Apps.hs
+++ b/src/GitHub/Previews/Endpoints/Apps.hs
@@ -1,6 +1,7 @@
-module GitHub.Previews.Endpoints.Apps
-    ( createAccessToken
-    , createAccessTokenR
+module GitHub.Previews.Endpoints.Apps (
+    createAccessToken,
+    createAccessTokenR,
+    module GitHub.Previews.Data,
     ) where
 
 import GitHub.Internal.Prelude

--- a/src/GitHub/Previews/Endpoints/Checks/CheckRuns.hs
+++ b/src/GitHub/Previews/Endpoints/Checks/CheckRuns.hs
@@ -1,0 +1,38 @@
+module GitHub.Previews.Endpoints.Checks.CheckRuns (
+    createCheckRun,
+    createCheckRunR,
+    updateCheckRun,
+    updateCheckRunR,
+    module GitHub.Previews.Data,
+    ) where
+
+import GitHub.Data
+import GitHub.Internal.Prelude
+import GitHub.Request
+import Prelude ()
+
+import GitHub.Previews.Data
+
+checkRun :: Auth -> Name Owner -> Name Repo -> Id CheckRun -> IO (Either Error CheckRun)
+checkRun auth owner repo crid =
+    executeRequest auth $ checkRunR owner repo crid
+
+checkRunR :: Name Owner -> Name Repo -> Id CheckRun -> GenRequest 'MtAntiopePreview 'RO CheckRun
+checkRunR owner repo crid =
+    Query ["repos", toPathPart owner, toPathPart repo, "check-runs", toPathPart crid] mempty
+
+createCheckRun :: Auth -> Name Owner -> Name Repo -> NewCheckRun -> IO (Either Error CheckRun)
+createCheckRun auth owner repo =
+    executeRequest auth . createCheckRunR owner repo
+
+createCheckRunR :: Name Owner -> Name Repo -> NewCheckRun -> GenRequest 'MtAntiopePreview 'RW CheckRun
+createCheckRunR owner repo =
+    Command Post ["repos", toPathPart owner, toPathPart repo, "check-runs"] . encode
+
+updateCheckRun :: Auth -> Name Owner -> Name Repo -> Id CheckRun -> EditCheckRun -> IO (Either Error CheckRun)
+updateCheckRun auth owner repo crid =
+    executeRequest auth . updateCheckRunR owner repo crid
+
+updateCheckRunR :: Name Owner -> Name Repo -> Id CheckRun -> EditCheckRun -> GenRequest 'MtAntiopePreview 'RW CheckRun
+updateCheckRunR owner repo crid =
+    Command Patch ["repos", toPathPart owner, toPathPart repo, "check-runs", toPathPart crid] . encode


### PR DESCRIPTION
Adds types, parsers and endpoints to support [check runs](https://developer.github.com/v3/checks/runs/). The ability to create and update check runs is only available when authenticated as a [GitHub App](https://developer.github.com/v3/apps/).