### PR TITLE
Code removal

### DIFF
--- a/github-previews.cabal
+++ b/github-previews.cabal
@@ -31,7 +31,6 @@ library
     , bytestring  >= 0.10.4.0
     , github      >= 0.24 && < 0.25
     , http-client >= 0.5.12
-    , mtl         >= 2.2.1
     , tagged      >= 0.8.5
     , text        >= 1.2.0.6
 

--- a/src/GitHub/Previews/Auth.hs
+++ b/src/GitHub/Previews/Auth.hs
@@ -10,9 +10,6 @@ import GitHub.Auth (AuthMethod (..))
 import qualified Data.ByteString     as BS
 import qualified Network.HTTP.Client as HTTP
 
--- | Custom API endpoint without trailing slash
-type Endpoint = Text
-
 type Token = BS.ByteString
 
 -- | The Github App auth data type

--- a/src/GitHub/Previews/Data/Request.hs
+++ b/src/GitHub/Previews/Data/Request.hs
@@ -7,7 +7,6 @@ import GitHub.Request
 
 import Data.Tagged (Tagged (..))
 
-data PreviewMediaType
 data MtWyandotte       -- ^ @application/vnd.github.wyandotte-preview+json@ <https://developer.github.com/v3/previews/#migrations>
 data MtBarredRock      -- ^ @application/vnd.github.barred-rock-preview+json@ <https://developer.github.com/v3/previews/#source-import>
 data MtAntMan          -- ^ @application/vnd.github.ant-man-preview+json@ <https://developer.github.com/v3/previews/#enhanced-deployments>

--- a/src/GitHub/Previews/Endpoints/Apps.hs
+++ b/src/GitHub/Previews/Endpoints/Apps.hs
@@ -1,5 +1,4 @@
 module GitHub.Previews.Endpoints.Apps (
-    createAccessToken,
     createAccessTokenR,
     module GitHub.Previews.Data,
     ) where
@@ -11,11 +10,6 @@ import GitHub.Data
 import GitHub.Request
 
 import GitHub.Previews.Data
-
--- | Create an access token for a given installation.
-createAccessToken :: AppAuth -> Id Installation -> IO (Either Error AccessToken)
-createAccessToken auth installation =
-    executeRequest auth $ createAccessTokenR installation
 
 -- | Create an access token for a given installation.
 -- See <https://developer.github.com/v3/apps/#create-a-new-installation-token>

--- a/src/GitHub/Previews/Endpoints/Checks/CheckRuns.hs
+++ b/src/GitHub/Previews/Endpoints/Checks/CheckRuns.hs
@@ -1,9 +1,6 @@
 module GitHub.Previews.Endpoints.Checks.CheckRuns (
-    checkRun,
     checkRunR,
-    createCheckRun,
     createCheckRunR,
-    updateCheckRun,
     updateCheckRunR,
     module GitHub.Previews.Data,
     ) where
@@ -15,30 +12,15 @@ import Prelude ()
 
 import GitHub.Previews.Data
 
--- | Get a check run.
-checkRun :: Auth -> Name Owner -> Name Repo -> Id CheckRun -> IO (Either Error CheckRun)
-checkRun auth owner repo crid =
-    executeRequest auth $ checkRunR owner repo crid
-
 -- | Get a check run. See <https://developer.github.com/v3/checks/runs/#get-a-single-check-run>
 checkRunR :: Name Owner -> Name Repo -> Id CheckRun -> GenRequest ('MtPreview MtAntiope) 'RO CheckRun
 checkRunR owner repo crid =
     Query ["repos", toPathPart owner, toPathPart repo, "check-runs", toPathPart crid] mempty
 
--- | Create a check run.
-createCheckRun :: Auth -> Name Owner -> Name Repo -> NewCheckRun -> IO (Either Error CheckRun)
-createCheckRun auth owner repo =
-    executeRequest auth . createCheckRunR owner repo
-
 -- | Create a check run. See <https://developer.github.com/v3/checks/runs/#create-a-check-run>
 createCheckRunR :: Name Owner -> Name Repo -> NewCheckRun -> GenRequest ('MtPreview MtAntiope) 'RW CheckRun
 createCheckRunR owner repo =
     Command Post ["repos", toPathPart owner, toPathPart repo, "check-runs"] . encode
-
--- | Update a check run.
-updateCheckRun :: Auth -> Name Owner -> Name Repo -> Id CheckRun -> EditCheckRun -> IO (Either Error CheckRun)
-updateCheckRun auth owner repo crid =
-    executeRequest auth . updateCheckRunR owner repo crid
 
 -- | Update a check run. See <https://developer.github.com/v3/checks/runs/#update-a-check-run>
 updateCheckRunR :: Name Owner -> Name Repo -> Id CheckRun -> EditCheckRun -> GenRequest ('MtPreview MtAntiope) 'RW CheckRun


### PR DESCRIPTION
Removes all endpoint functions based on the `executeRequest` pattern. This is for consistency with the `github` library which removed these functions in https://github.com/phadej/github/pull/415 and now provides the [`github`](http://hackage.haskell.org/package/github-0.24/docs/GitHub-Request.html#v:github) combinator for working with functions which return request types.